### PR TITLE
Bugfix Fallback Comment

### DIFF
--- a/lib/variables.js
+++ b/lib/variables.js
@@ -9,9 +9,13 @@ module.exports = function(root) {
   function replaceDefinition(declaration) {
     if (declaration.prop.match(/^\-\-/)) {
       declaration.prop = declaration.prop.replace(/^\-\-/, '$');
+      var commentTest = /\s\/\*(?:(?!\*\/)[\s\S])*\*\/|[\r\n\t]+/g;
+      var fallback = declaration.value.match(commentTest);
+      var value = declaration.value.replace(commentTest, '');
       variables.push({
         name: declaration.prop,
-        value: declaration.value
+        value: value,
+        fallback: fallback || null
       });
     }
   }
@@ -23,7 +27,7 @@ module.exports = function(root) {
     if (inner.body.indexOf(',') !== -1) {
       var n = inner.body.indexOf(',');
       var fallback = ' /* Fallback value: ' + inner.body.split(',')[1] + ' */';
-      replacement = inner.body.substring(0, n); 
+      replacement = inner.body.substring(0, n);
     } else {
       replacement = inner.body;
     }
@@ -56,7 +60,8 @@ module.exports = function(root) {
 
   definitions = '\n// Converted Variables\n\n';
   variables.forEach(function(v) {
-    definitions += v.name + ': ' + v.value + ' !default;\n';
+    definitions += v.name + ': ' + v.value + ' !default;';
+    definitions += (v.fallback ? v.fallback : '') + '\n';
   });
 
   return {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "mocha": "^2.1.0",
-    "node-sass": "^1.2.3",
+    "node-sass": "^3.4.1",
     "rework": "^1.0.1",
     "rework-npm": "^1.0.0"
   },

--- a/test/fixtures/custom-media.css
+++ b/test/fixtures/custom-media.css
@@ -23,7 +23,7 @@ body {
   --blue: #00f;
   --red: #f00;
 
-  --green: var(--blue);
+  --green: var(--blue, blue);
   --space-1: 1em;
   --space-2: 2em;
   --space-4: 4em;

--- a/test/fixtures/custom-media.expected.scss
+++ b/test/fixtures/custom-media.expected.scss
@@ -3,7 +3,7 @@
 
 $blue: #00f !default;
 $red: #f00 !default;
-$green: $blue !default;
+$green: $blue !default; /* Fallback value:  blue */
 $space-1: 1em !default;
 $space-2: 2em !default;
 $space-4: 4em !default;

--- a/test/fixtures/custom-media.output.scss
+++ b/test/fixtures/custom-media.output.scss
@@ -3,7 +3,7 @@
 
 $blue: #00f !default;
 $red: #f00 !default;
-$green: $blue !default;
+$green: $blue !default; /* Fallback value:  blue */
 $space-1: 1em !default;
 $space-2: 2em !default;
 $space-4: 4em !default;


### PR DESCRIPTION
@jxnblk Moved the fallback comment to after `!default` flag instead of before. For example:

This:
`--button-font-weight: var(--bold-font-weight, bold);`

would compile to:
`$button-font-weight: $bold-font-weight !default; /* Fallback value:  bold */`

Related to: https://github.com/basscss/basscss-sass/issues/6